### PR TITLE
Update Codecov Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_script: redis-cli ping
 script:
   - nosetests
 
-#after_success:
-#  - codecov
+after_success:
+  - codecov
 
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_script: redis-cli ping
 script:
   - nosetests
 
-after_success:
-  - codecov
+#after_success:
+#  - codecov
 
 services:
   - redis-server

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ pylint>=2.4.1
 
 # Code coverage
 coverage==4.5.4
-codecov==2.0.15
+codecov==2.1.10


### PR DESCRIPTION
Codecov had some backend changes earlier this year. As a result, the old `codecov` won't be able to upload the result and will cause a 400 error. Although the error will not cause the test to fail, Codecov won't be able to process the report.

See [here](https://github.com/codecov/codecov-python/issues/251) for someone reporting this issue to the developer.

This PR updates the version of Codecov to solve the issue.

|                | Before | After |
|----------------|--------|-------|
| Screenshot     | ![image](https://user-images.githubusercontent.com/4352234/95936174-fcad2200-0da2-11eb-8447-d7233ab22f2e.png) ![image](https://user-images.githubusercontent.com/4352234/95936541-d3d95c80-0da3-11eb-9ac0-8c8a8c9ec934.png) | ![image](https://user-images.githubusercontent.com/4352234/95936248-21a19500-0da3-11eb-8362-8538c23480b5.png) ![image](https://user-images.githubusercontent.com/4352234/95936582-ece20d80-0da3-11eb-9bd1-8d02928a6fff.png) |
| Travis CI Log  | https://travis-ci.com/github/iLtc/lab-travis-ci/builds/189863602 | https://travis-ci.com/github/iLtc/lab-travis-ci/builds/189863764 |
| Codecov Report |  https://codecov.io/gh/iLtc/lab-travis-ci/commit/d4e9a4af0eb473c0823e6a0878d6e1758ca553f8  | https://codecov.io/gh/iLtc/lab-travis-ci/commit/4c671eff6b09bcb3b168a10dd487b574e2fa2906 |